### PR TITLE
Prevent favicon.ico requests for stats page

### DIFF
--- a/src/stats.c
+++ b/src/stats.c
@@ -2335,6 +2335,7 @@ static void stats_dump_html_head(struct appctx *appctx, struct uri_auth *uri)
 	              "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\"\n"
 	              "\"http://www.w3.org/TR/html4/loose.dtd\">\n"
 	              "<html><head><title>Statistics Report for " PRODUCT_NAME "%s%s</title>\n"
+		      "<link rel=\"icon\" href=\"data:,\">\n"
 	              "<meta http-equiv=\"content-type\" content=\"text/html; charset=iso-8859-1\">\n"
 	              "<style type=\"text/css\"><!--\n"
 	              "body {"


### PR DESCRIPTION
Haproxy stats page don't have a favicon.ico, but browsers always makes a request for it.
This lead to errors during stats page requests:

Aug 18 08:46:41 somehost.example.net haproxy[1521534]: X.X.X.X:61403 [18/Aug/2020:08:46:41.437] stats stats/ -1/-1/-1/-1/0 503 222 - - SC-- 2/2/0/0/0 0/0 "GET /favicon.ico HTTP/1.1"
Aug 18 08:46:42 somehost.example.net haproxy[1521534]: X.X.X.X:61403 [18/Aug/2020:08:46:42.650] stats stats/ -1/-1/-1/-1/0 503 222 - - SC-- 2/2/0/0/0 0/0 "GET /favicon.ico HTTP/1.1"

Patch provided disables favicon.ico requests for haproxy stats page.